### PR TITLE
docs: improved launch url docs

### DIFF
--- a/docs/v1.2/core api/3. launch url structure.md
+++ b/docs/v1.2/core api/3. launch url structure.md
@@ -59,11 +59,13 @@ Every launch URL must include these three parameters:
 
 ## Optional Parameters
 
-| Parameter             | Description                                            | Default |
-|-----------------------|--------------------------------------------------------|---------|
-| levels                | Enable/disable internal free rounds system             | true    |
-| show_base_currency    | Show base currency equivalent values                   | true    |
-| prevent_multi_session | Prevent opening the our games in multiple browser tabs | false   |
+| Parameter                    | Description                                                         | Default |
+|------------------------------|---------------------------------------------------------------------|---------|
+| levels                       | Enable/disable internal free rounds system                          | true    |
+| show_base_currency           | Show base currency equivalent values                                | true    |
+| prevent_multi_session        | Prevent opening the our games in multiple browser tabs              | false   |
+| free-rounds-decline          | Display Decline button in free rounds confirmation window           | true    |
+| free-rounds-bet-amount-fixed | Fix bet at maximum amount, preventing lower bets during free rounds | false   |
 
 ### Free rounds / Levels
 
@@ -73,6 +75,12 @@ If you haven't integrated free rounds yet, or don't want to use internal free ro
 To disable levels you need to use: `?levels=false` in the launcher URL
 
 By disabling levels you still can use external free rounds, which you can create with additional API requests.
+
+#### Free rounds options
+
+- **free-rounds-decline**: Boolean value indicating whether to display a Decline button in the free rounds confirmation window. When set to `true`, players will have the option to decline free rounds. Default is `true`.
+
+- **free-rounds-bet-amount-fixed**: Boolean value indicating whether to fix the bet at the maximum amount during free rounds. When set to `true`, players will not be able to set a lower bet amount than the maximum during free rounds. Default is `false`.
 
 #### Show base currency
 
@@ -92,4 +100,6 @@ https://staging.fastplaynetwork.com/games/ph_limbo_97/
 &currency=USD
 &levels=false
 &prevent-multi-session=true
+&free-rounds-decline=false
+&free-rounds-bet-amount-fixed=true
 ```


### PR DESCRIPTION
* добавлены два параметра в launch url:
free-rounds-decline - отобразить кнопку Decline в окне подтверждения начала фрираундов, по умолчанию - true
free-rounds-bet-amount-fixed - зафиксировать ставку на максимальной, не давать возможности ставить меньше максимальной ставки